### PR TITLE
Fix libname to avoid blacklisting by gst

### DIFF
--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -1,11 +1,11 @@
-plugin_LTLIBRARIES = libgstvimba.la
+plugin_LTLIBRARIES = libgstvimbasrc.la
 
 # sources used to compile this plug-in
-libgstvimba_la_SOURCES = gstvimbasrc.c gstvimbasrc.h vimbacamera.h vimbacamera.c vimba.h vimba.c pixelformat.h pixelformat.c
+libgstvimbasrc_la_SOURCES = gstvimbasrc.c gstvimbasrc.h vimbacamera.h vimbacamera.c vimba.h vimba.c pixelformat.h pixelformat.c
 
 # compiler and linker flags used to compile this plugin, set in configure.ac
-libgstvimba_la_CFLAGS = $(GST_CFLAGS)
-libgstvimba_la_LIBADD = $(GST_LIBS)
-libgstvimba_la_LDFLAGS = -lVimbaC $(GST_PLUGIN_LDFLAGS)
-libgstvimba_la_LIBTOOLFLAGS = $(GST_PLUGIN_LIBTOOLFLAGS)
+libgstvimbasrc_la_CFLAGS = $(GST_CFLAGS)
+libgstvimbasrc_la_LIBADD = $(GST_LIBS)
+libgstvimbasrc_la_LDFLAGS = -lVimbaC $(GST_PLUGIN_LDFLAGS)
+libgstvimbasrc_la_LIBTOOLFLAGS = $(GST_PLUGIN_LIBTOOLFLAGS)
 


### PR DESCRIPTION
GStreamer requires to have library name the same as gst element:
libgstvimba must be renamed to libgstvimbasrc to be visibale by gst plugin loader.
Otherwise the plugin gets blacklisted.