### PR TITLE
Open device on change_state

### DIFF
--- a/plugins/gstvimbasrc.c
+++ b/plugins/gstvimbasrc.c
@@ -66,7 +66,11 @@ enum
     PROP_0,
     PROP_CAMERA,
     PROP_OFFSET_X,
-    PROP_OFFSET_Y
+    PROP_OFFSET_Y,
+    PROP_EXPOSURE,
+    PROP_EXPOSURE_AUTO,
+    PROP_GAIN,
+    PROP_GAIN_AUTO
 };
 
 #define VIMBASRC_VIDEO_CAPS GST_VIDEO_CAPS_MAKE (GST_VIDEO_FORMATS_ALL) ";" \
@@ -172,6 +176,57 @@ gst_vimba_src_class_init (GstVimbaSrcClass * klass)
         )
     );
 
+    g_object_class_install_property(
+        gobject_class,
+        PROP_EXPOSURE,
+        g_param_spec_float(
+            "exposure",
+            "Exposure",
+            "Exposure",
+            0.0f,
+            G_MAXFLOAT,
+            0,
+            G_PARAM_READWRITE
+        )
+    );
+
+    g_object_class_install_property(
+        gobject_class,
+        PROP_EXPOSURE_AUTO,
+        g_param_spec_string(
+            "exposure-auto",
+            "Exposure Auto",
+            "Exposure Auto",
+            "Off",
+            G_PARAM_READWRITE
+        )
+    );
+
+    g_object_class_install_property(
+        gobject_class,
+        PROP_GAIN,
+        g_param_spec_float(
+            "gain",
+            "Gain",
+            "Gain",
+            0.0f,
+            G_MAXFLOAT,
+            0,
+            G_PARAM_READWRITE
+        )
+    );
+
+    g_object_class_install_property(
+        gobject_class,
+        PROP_GAIN_AUTO,
+        g_param_spec_string(
+            "gain-auto",
+            "Gain Auto",
+            "Gain Auto",
+            "Off",
+            G_PARAM_READWRITE
+        )
+    );
 }
 
 static void
@@ -219,6 +274,26 @@ gst_vimba_src_set_property (GObject * object, guint property_id,
             vimbacamera_set_feature_int(vimbasrc->camera, "OffsetY", offset_y);
             g_mutex_unlock(&vimbasrc->config_lock);
             break;
+        case PROP_EXPOSURE:
+            g_mutex_lock(&vimbasrc->config_lock);
+            vimbacamera_set_exposure(vimbasrc->camera, g_value_get_float(value));
+            g_mutex_unlock(&vimbasrc->config_lock);
+            break;
+        case PROP_EXPOSURE_AUTO:
+            g_mutex_lock(&vimbasrc->config_lock);
+            vimbacamera_set_exposure_auto(vimbasrc->camera, g_value_get_string(value));
+            g_mutex_unlock(&vimbasrc->config_lock);
+            break;
+        case PROP_GAIN:
+            g_mutex_lock(&vimbasrc->config_lock);
+            vimbacamera_set_gain(vimbasrc->camera, g_value_get_float(value));
+            g_mutex_unlock(&vimbasrc->config_lock);
+            break;
+        case PROP_GAIN_AUTO:
+            g_mutex_lock(&vimbasrc->config_lock);
+            vimbacamera_set_gain_auto(vimbasrc->camera, g_value_get_string(value));
+            g_mutex_unlock(&vimbasrc->config_lock);
+            break;
         default:
             G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
             break;
@@ -242,6 +317,18 @@ gst_vimba_src_get_property (GObject * object, guint property_id,
             break;
         case PROP_OFFSET_Y:
             g_value_set_int(value, vimbacamera_get_feature_int(vimbasrc->camera, "OffsetY"));
+            break;
+        case PROP_EXPOSURE:
+            g_value_set_float(value, vimbacamera_get_exposure(vimbasrc->camera));
+            break;
+        case PROP_EXPOSURE_AUTO:
+            g_value_set_string(value, vimbacamera_get_exposure_auto(vimbasrc->camera));
+            break;
+        case PROP_GAIN:
+            g_value_set_float(value, vimbacamera_get_gain(vimbasrc->camera));
+            break;
+        case PROP_GAIN_AUTO:
+            g_value_set_string(value, vimbacamera_get_gain_auto(vimbasrc->camera));
             break;
         default:
             G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);

--- a/plugins/vimba.c
+++ b/plugins/vimba.c
@@ -31,7 +31,7 @@ void vimba_discover(Vimba* vimba) {
             err = VmbFeatureCommandRun(gVimbaHandle, "GeVDiscoveryAllOnce");
         }
     } else {
-        g_error("No transport layer");
+        g_message("No transport layer");
     }
     if (VmbErrorSuccess == err) {
         if (vimba->camera_list) {
@@ -39,6 +39,10 @@ void vimba_discover(Vimba* vimba) {
             vimba->camera_list = NULL;
         }
         err = VmbCamerasList(NULL, 0, &vimba->count, sizeof(VmbCameraInfo_t) );
+        if (vimba->count == 0) {
+            g_message("No cameras found");
+            return;
+        }
         g_message("Found %d cameras", vimba->count);
         if (VmbErrorSuccess == err) {
             vimba->camera_list = (VmbCameraInfo_t*) malloc(
@@ -56,6 +60,6 @@ void vimba_discover(Vimba* vimba) {
             }
         }
     } else {
-        g_error("Unable to discover cameras");
+        g_message("Unable to discover cameras");
     }
 }

--- a/plugins/vimbacamera.c
+++ b/plugins/vimbacamera.c
@@ -42,11 +42,13 @@ VimbaCamera* vimbacamera_init() {
     VimbaCamera* camera = malloc(sizeof(VimbaCamera));
     camera->started = FALSE;
     camera->open = FALSE;
+    camera->camera_id = NULL;
     return camera;
 }
 
 void vimbacamera_destroy (VimbaCamera * camera) {
     g_async_queue_unref(frame_queue);
+    g_free(camera->camera_id);
     if (camera) {
         free(camera);
     }
@@ -317,6 +319,17 @@ long long vimbacamera_get_feature_int(VimbaCamera * camera, const char * name) {
     VmbError_t err = VmbFeatureIntGet(camera->camera_handle, name, &value);
     VMB_HANDLE_FEATURE_ERROR(err);
     return value;
+}
+
+void vimbacamera_set_camera_id(VimbaCamera * camera, const char * value)
+{
+    g_free(camera->camera_id);
+    camera->camera_id = g_strdup(value);
+}
+
+const char * vimbacamera_get_camera_id(VimbaCamera * camera)
+{
+    return camera->camera_id;
 }
 
 void vimbacamera_list_features(VimbaCamera * camera) {

--- a/plugins/vimbacamera.h
+++ b/plugins/vimbacamera.h
@@ -29,6 +29,10 @@ struct _VimbaCamera {
     VmbUint64_t base_time;
     gboolean    open;
     gboolean    started;
+    double      exposure;
+    char*       exposure_auto;
+    double      gain;
+    char*       gain_auto;
 };
 
 VimbaCamera* vimbacamera_init();
@@ -45,6 +49,14 @@ void         vimbacamera_set_feature_int(VimbaCamera * camera, const char * name
 long long    vimbacamera_get_feature_int(VimbaCamera * camera, const char * name);
 void         vimbacamera_set_camera_id(VimbaCamera * camera, const char * value);
 const char * vimbacamera_get_camera_id(VimbaCamera * camera);
+void         vimbacamera_set_exposure(VimbaCamera * camera, float value);
+double       vimbacamera_get_exposure(VimbaCamera * camera);
+void         vimbacamera_set_exposure_auto(VimbaCamera * camera, const char * value);
+const char * vimbacamera_get_exposure_auto(VimbaCamera * camera);
+void         vimbacamera_set_gain(VimbaCamera * camera, float value);
+double       vimbacamera_get_gain(VimbaCamera * camera);
+void         vimbacamera_set_gain_auto(VimbaCamera * camera, const char * value);
+const char * vimbacamera_get_gain_auto(VimbaCamera * camera);
 void         vimbacamera_list_features(VimbaCamera * camera);
 
 #endif

--- a/plugins/vimbacamera.h
+++ b/plugins/vimbacamera.h
@@ -12,7 +12,7 @@ GAsyncQueue* frame_queue;
 
 typedef struct _VimbaCamera VimbaCamera;
 struct _VimbaCamera {
-    const char* camera_id;
+    char*       camera_id;
     VmbHandle_t camera_handle;
     VmbInt64_t  max_width;
     VmbInt64_t  max_height;
@@ -43,6 +43,8 @@ VmbFrame_t * vimbacamera_consume_frame (VimbaCamera * camera);
 void         vimbacamera_queue_frame (VimbaCamera * camera, VmbFrame_t * frame);
 void         vimbacamera_set_feature_int(VimbaCamera * camera, const char * name, int value);
 long long    vimbacamera_get_feature_int(VimbaCamera * camera, const char * name);
+void         vimbacamera_set_camera_id(VimbaCamera * camera, const char * value);
+const char * vimbacamera_get_camera_id(VimbaCamera * camera);
 void         vimbacamera_list_features(VimbaCamera * camera);
 
 #endif


### PR DESCRIPTION
g_error leads to call abort() and coredump.
And usually g_error is used when there is fatal error.
And should not be used in such way.

It is better to try to open device on change_state
and return gst error, and close pipeline, without a crash.

Added vimbacamera_set_camera_id/vimbacamera_get_camera_id
to be able to control camera id.
And props should not be accessed directly.